### PR TITLE
fix: spacing after 'sent in txn'

### DIFF
--- a/src/app/_components/request-tokens-form.tsx
+++ b/src/app/_components/request-tokens-form.tsx
@@ -28,8 +28,7 @@ export default function RequestTokensForm() {
         title: "Success!",
         description: (
           <span>
-            tHOKU sent in txn
-            {state.result.txHash.slice(0, 6)}...
+            tHOKU sent in txn {state.result.txHash.slice(0, 6)}...
             {state.result.txHash.slice(-6)}
           </span>
         ),


### PR DESCRIPTION
<img width="412" alt="Screenshot 2025-01-13 at 11 58 20 AM" src="https://github.com/user-attachments/assets/1594c0df-25cf-407d-870e-e17b6fad5471" />

Changes the `tHOKU sent in txn0x1234...5678` (above) to include a space after `txn`